### PR TITLE
Meta object plumbed through control to PRMSGroundwater netcdf files

### DIFF
--- a/autotest/test_meta.py
+++ b/autotest/test_meta.py
@@ -1,0 +1,48 @@
+import pytest
+from pynhm.base.meta import Meta
+from pynhm.hydrology.PRMSGroundwater import PRMSGroundwater
+
+
+@pytest.fixture(scope="function")
+def meta():
+    return Meta()
+
+
+def test_init(meta):
+    # some random checks
+    assert "nhru" in meta.dimensions.keys()
+    assert "transp_on_dynamic" in meta.control.keys()
+    assert "covden_win" in meta.parameters.keys()
+    assert "transp_on" in meta.variables.keys()
+    return
+
+
+def test_get_subclass(meta):
+    gw_var_meta = meta.get_var_subclass("PRMSGroundwater")
+    gw_vars = PRMSGroundwater.get_variables()
+    assert set(gw_var_meta.keys()) == set(gw_vars)
+
+    gw_input_meta = meta.get_inputs_subclass("PRMSGroundwater")
+    gw_inputs = PRMSGroundwater.get_inputs()
+    assert set(gw_input_meta.keys()) == set(gw_inputs)
+
+    return
+
+
+def test_get_in_list(meta):
+    gw_vars = PRMSGroundwater.get_variables()
+    gw_var_meta = meta.get_vars(gw_vars)
+    assert set(gw_var_meta.keys()) == set(gw_vars)
+
+    gw_inputs = PRMSGroundwater.get_inputs()
+    gw_input_meta = meta.get_vars(gw_inputs)
+    assert set(gw_input_meta.keys()) == set(gw_inputs)
+
+    # There are dimensions in the PRMSGroundwater parameters
+    # so these are not in the returned set. Not clear the best
+    # way to go
+    # gw_params = PRMSGroundwater.get_parameters()
+    # gw_param_meta = meta.get_params(gw_params)
+    # assert set(gw_param_meta.keys()) == set(gw_params)
+
+    return

--- a/autotest/test_meta.py
+++ b/autotest/test_meta.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pynhm.base.meta import Meta
 from pynhm.hydrology.PRMSGroundwater import PRMSGroundwater
 

--- a/pynhm/__init__.py
+++ b/pynhm/__init__.py
@@ -18,6 +18,7 @@ from .utils import (
     NetCdfWrite,
     PrmsParameters,
 )
+
 from .version import __author__, __author_email__, __version__
 
 __all__ = [

--- a/pynhm/__init__.py
+++ b/pynhm/__init__.py
@@ -18,7 +18,6 @@ from .utils import (
     NetCdfWrite,
     PrmsParameters,
 )
-
 from .version import __author__, __author_email__, __version__
 
 __all__ = [

--- a/pynhm/base/control.py
+++ b/pynhm/base/control.py
@@ -5,9 +5,9 @@ from typing import Union
 
 import numpy as np
 
+from ..base.meta import Meta
 from ..utils import ControlVariables
 from .accessor import Accessor
-from ..base.meta import Meta
 
 fileish = Union[str, pl.PosixPath]
 

--- a/pynhm/base/control.py
+++ b/pynhm/base/control.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from ..utils import ControlVariables
 from .accessor import Accessor
+from ..base.meta import Meta
 
 fileish = Union[str, pl.PosixPath]
 
@@ -45,7 +46,7 @@ class Control(Accessor):
         self._previous_time = None
         self._i_time = 0
 
-        # self.metadata
+        self.meta = Meta()
         # This will have the time dimension name
         # This will have the time coordimate name
 

--- a/pynhm/base/meta.py
+++ b/pynhm/base/meta.py
@@ -1,0 +1,78 @@
+import pathlib as pl
+from typing import Union, Iterable
+
+from ..constants import __pynhm_root__
+
+import yaml
+
+fileish = Union[str, pl.Path]
+
+
+def load_yaml_file(the_file):
+    with pl.Path(the_file).open("r") as file_stream:
+        data = yaml.load(file_stream, Loader=yaml.Loader)
+    return data
+
+
+class Meta:
+    def __init__(
+        self,
+        dimensions: fileish = (
+            __pynhm_root__ / "static/metadata/dimensions.yaml"
+        ),
+        control: fileish = (__pynhm_root__ / "static/metadata/control.yaml"),
+        parameters: fileish = (
+            __pynhm_root__ / "static/metadata/parameters.yaml"
+        ),
+        variables: fileish = (
+            __pynhm_root__ / "static/metadata/variables.yaml"
+        ),
+    ):
+
+        self.name = "Meta"
+
+        self.dimensions = load_yaml_file(dimensions)
+        self.control = load_yaml_file(control)
+        self.parameters = load_yaml_file(parameters)
+        self.variables = load_yaml_file(variables)
+
+        return
+
+    def get_var_subclass(self, subclass_name: str) -> dict:
+        """Get the variable metadata for the supplied subclass."""
+        return {
+            key: value
+            for key, value in self.variables.items()
+            if subclass_name in value["modules"]
+        }
+
+    def get_inputs_subclass(self, subclass_name: str) -> dict:
+        """Get the inputs metadata for the supplied subclass."""
+        return {
+            key: value
+            for key, value in self.variables.items()
+            if ("input_to" in value) and (subclass_name in value["input_to"])
+        }
+
+    def _get_meta_in_list(self, meta: str, the_list: Iterable) -> dict:
+        return {
+            key: value
+            for key, value in getattr(self, meta).items()
+            if key in the_list
+        }
+
+    def get_dims(self, var_list: Iterable) -> dict:
+        """Get the variable metadata for the supplied subclass."""
+        return self._get_meta_in_list("dimensions", var_list)
+
+    def get_control(self, var_list: Iterable) -> dict:
+        """Get the variable metadata for the supplied subclass."""
+        return self._get_meta_in_list("control", var_list)
+
+    def get_params(self, inputs_list: Iterable) -> dict:
+        """Get the variable metadata for the supplied subclass."""
+        return self._get_meta_in_list("parameters", inputs_list)
+
+    def get_vars(self, var_list: Iterable) -> dict:
+        """Get the variable metadata for the supplied subclass."""
+        return self._get_meta_in_list("variables", var_list)

--- a/pynhm/base/meta.py
+++ b/pynhm/base/meta.py
@@ -31,6 +31,8 @@ class Meta:
 
         self.name = "Meta"
 
+        print(dimensions)
+
         self.dimensions = load_yaml_file(dimensions)
         self.control = load_yaml_file(control)
         self.parameters = load_yaml_file(parameters)

--- a/pynhm/base/meta.py
+++ b/pynhm/base/meta.py
@@ -1,9 +1,9 @@
 import pathlib as pl
-from typing import Union, Iterable
-
-from ..constants import __pynhm_root__
+from typing import Iterable, Union
 
 import yaml
+
+from ..constants import __pynhm_root__
 
 fileish = Union[str, pl.Path]
 

--- a/pynhm/constants.py
+++ b/pynhm/constants.py
@@ -1,0 +1,9 @@
+import pathlib as pl
+import numpy as np
+
+__pynhm_root__ = pl.Path(__file__).parent
+
+zero = np.zeros([1])[0]
+one = np.ones([1])[0]
+
+fill_value_f4 = 9.96921e36

--- a/pynhm/constants.py
+++ b/pynhm/constants.py
@@ -1,4 +1,5 @@
 import pathlib as pl
+
 import numpy as np
 
 __pynhm_root__ = pl.Path(__file__).parent

--- a/pynhm/hydrology/PRMSCanopy.py
+++ b/pynhm/hydrology/PRMSCanopy.py
@@ -40,14 +40,15 @@ class PRMSCanopy(StorageUnit):
         verbose: bool = False,
     ):
 
+        self.name = "PRMSCanopy"
         verbose = True
         super().__init__(
             control=control,
             params=params,
             verbose=verbose,
+            subclass_name=self.name,
         )
 
-        self.name = "PRMSCanopy"
         # self._current_time = self.control.current_time
 
         # store dependencies
@@ -128,11 +129,9 @@ class PRMSCanopy(StorageUnit):
             "net_rain",
             "net_snow",
             "intcp_evap",
-            "rainfall_adj",
-            "snowfall_adj",
-            "potet",
-            "interception_form",
-            "intcp_transp_on",
+            "intcp_form",
+            "intcp_transp_on",  # this is private in prms6 and is not in the metadata
+            # i defined metadata for it in a very adhoc way
         )
 
     def advance(self):
@@ -158,9 +157,9 @@ class PRMSCanopy(StorageUnit):
             v = getattr(self, key)
             v[:] = value.current
 
-        self.interception_form[:] = RAIN
+        self.intcp_form[:] = RAIN
         idx = np.where(self.hru_snow > 0)
-        self.interception_form[idx] = SNOW
+        self.intcp_form[idx] = SNOW
 
         assert self.pkwater_equiv.shape == (self.nhru,)
 
@@ -415,7 +414,7 @@ class PRMSCanopy(StorageUnit):
         # evsn = np.where(prcp < NEARZERO, potet * self.potet_sublim, 0.)
         # intcp_stor_save = intcp_stor.copy()
         # depth = np.where(
-        #     self.interception_form == SNOW,
+        #     self.intcp_form == SNOW,
         #     intcp_stor - evsn,
         #     intcp_stor - evrn,
         # )
@@ -430,7 +429,7 @@ class PRMSCanopy(StorageUnit):
                     evrn = potet[i] / epan_coef
                     evsn = potet[i] * self.potet_sublim[i]
 
-                    if self.interception_form[i] == SNOW:
+                    if self.intcp_form[i] == SNOW:
                         z = intcpstor - evsn
                         if z > 0:
                             intcpstor = z

--- a/pynhm/hydrology/PRMSGroundwater.py
+++ b/pynhm/hydrology/PRMSGroundwater.py
@@ -31,13 +31,19 @@ class PRMSGroundwater(StorageUnit):
         verbose: bool = False,
     ) -> "PRMSGroundwater":
 
+        self.name = "PRMSGroundwater"
         super().__init__(
             control=control,
             params=params,
             verbose=verbose,
+            subclass_name=self.name,
         )
 
-        self.name = "PRMSGroundwater"
+        # self.budget = Budget({
+        #     "gwres_flow": {self.gwres_flow, self.met['gwres_flow'], self.name}
+        #     "gwres_in",
+        #     "gwres_sink",
+        #     "gwres_stor",
 
         self._input_variables_dict = {}
         self._input_variables_dict["soil_to_gw"] = adapter_factory(

--- a/pynhm/static/metadata/dimensions.yaml
+++ b/pynhm/static/metadata/dimensions.yaml
@@ -1,3 +1,4 @@
+# Should time be in this list?
 ncascade:
   default: 0
   desc: Number of HRU links for cascading flow

--- a/pynhm/static/metadata/variables.yaml
+++ b/pynhm/static/metadata/variables.yaml
@@ -1484,6 +1484,8 @@ dprst_seep_hru:
     0: nhru
   modules:
   - srunoff
+  input_to:
+  - PRMSGroundwater
   type: D
   units: inches
 dprst_sroff_hru:
@@ -1840,6 +1842,7 @@ gwres_flow:
     0: ngw
   modules:
   - gwflow
+  - PRMSGroundwater
   type: F
   units: inches
 gwres_in:
@@ -1848,6 +1851,7 @@ gwres_in:
     0: ngw
   modules:
   - gwflow
+  - PRMSGroundwater
   type: D
   units: acre-inches
 gwres_sink:
@@ -1857,6 +1861,7 @@ gwres_sink:
     0: ngw
   modules:
   - gwflow
+  - PRMSGroundwater
   type: F
   units: inches
 gwres_stor:
@@ -1865,6 +1870,7 @@ gwres_stor:
     0: ngw
   modules:
   - gwflow
+  - PRMSGroundwater
   type: D
   units: inches
 gwstor_minarea_wb:
@@ -3204,6 +3210,8 @@ soil_to_gw:
     0: nhru
   modules:
   - soilzone
+  input_to:
+  - PRMSGroundwater
   type: F
   units: inches
 soil_to_ssr:
@@ -3298,6 +3306,8 @@ ssr_to_gw:
     0: nssr
   modules:
   - soilzone
+  input_to:
+  - PRMSGroundwater
   type: F
   units: inches
 ssres_flow:

--- a/pynhm/static/metadata/variables.yaml
+++ b/pynhm/static/metadata/variables.yaml
@@ -2007,6 +2007,8 @@ hru_ppt:
     0: nhru
   modules:
   - precipitation
+  input_to:
+  - PRMSCanopy
   type: F
   units: inches
 hru_rain:
@@ -2015,6 +2017,8 @@ hru_rain:
     0: nhru
   modules:
   - precipitation
+  input_to:
+  - PRMSCanopy
   type: F
   units: inches
 hru_snow:
@@ -2023,6 +2027,8 @@ hru_snow:
     0: nhru
   modules:
   - precipitation
+  input_to:
+  - PRMSCanopy
   type: F
   units: inches
 hru_sroffi:
@@ -2129,6 +2135,7 @@ intcp_evap:
     0: nhru
   modules:
   - intcp
+  - PRMSCanopy
   type: F
   units: inches
 intcp_form:
@@ -2137,6 +2144,7 @@ intcp_form:
     0: nhru
   modules:
   - intcp
+  - PRMSCanopy
   type: I
   units: none
 intcp_on:
@@ -2153,6 +2161,7 @@ intcp_stor:
     0: nhru
   modules:
   - intcp
+  - PRMSCanopy
   type: F
   units: inches
 interflow_max:
@@ -2456,6 +2465,7 @@ net_rain:
     0: nhru
   modules:
   - intcp
+  - PRMSCanopy
   type: F
   units: inches
 net_snow:
@@ -2464,6 +2474,7 @@ net_snow:
     0: nhru
   modules:
   - intcp
+  - PRMSCanopy
   type: F
   units: inches
 newsnow:
@@ -2653,6 +2664,8 @@ pkwater_equiv:
   modules:
   - climateflow
   - snowcomp
+  input_to:
+  - PRMSCanopy
   type: D
   units: inches
 potet:
@@ -2661,6 +2674,8 @@ potet:
     0: nhru
   modules:
   - potet
+  input_to:
+  - PRMSCanopy
   type: F
   units: inches
 potet_lower:
@@ -3867,6 +3882,17 @@ transp_on:
     0: nhru
   modules:
   - transpiration
+  input_to:
+  - PRMSCanopy
+  type: I
+  units: none
+intcp_transp_on:
+  desc: Flag indicating whether transpiration is occurring in the canopy (0=no;1=yes)
+  dimensions:
+    0: nhru
+  modules:
+  - transpiration
+  - PRMSCanopy
   type: I
   units: none
 unused_potet:

--- a/pynhm/utils/netcdf_utils.py
+++ b/pynhm/utils/netcdf_utils.py
@@ -193,6 +193,7 @@ class NetCdfWrite:
         name: fileish,
         hru_ids: arrayish,
         variables: listish,
+        var_meta: dict,
         time_units: str = "days since 1970-01-01 00:00:00",
         clobber: bool = True,
         zlib: bool = True,
@@ -234,6 +235,11 @@ class NetCdfWrite:
                 complevel=complevel,
                 chunksizes=tuple(chunk_sizes.values()),
             )
+            for key, val in var_meta.items():
+                # JLM this is a hack. either define an arg or edit the yaml or both
+                if key in ["dimensions"]:
+                    continue
+                self.variables[vv].setncattr(key, val)
 
     def __del__(self):
         self.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,11 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Hydrology
-url = https://github.com/langevin-usgs/prmsNHMpy
+url = https://github.com/EC-USGS/prmsNHMpy
 download_url = https://pypi.org/project/pynhm
 project_urls =
-    Bug Tracker = https://github.com/langevin-usgs/prmsNHMpy/issues
-    Source Code = https://github.com/langevin-usgs/prmsNHMpy
+    Bug Tracker = https://github.com/EC-USGS/prmsNHMpy/issues
+    Source Code = https://github.com/EC-USGS/prmsNHMpy
 
 [options]
 include_package_data = True  # includes files listed in MANIFEST.in
@@ -35,6 +35,10 @@ install_requires =
     pandas
     pyyaml
     netCDF4
+
+[options.package_data]
+pynhm =
+    static/metadata/*.yaml
 
 [sdist]
 formats = zip

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ python_requires = >=3.7
 install_requires =
     numpy
     pandas
+    pyyaml
     netCDF4
 
 [sdist]


### PR DESCRIPTION
@langevin There are some changes in canopy, i think they are mostly good or inconsequential. I noted that intcp_transp_on is private in PRMS6 and so there was no metadata for it. I added it to the metadata so it could be included in the output. 

The metadata is wired through to the netcdf outputs (at least for individual files). 

There are some interesting uses of metadata starting, the metadata lists "modules" (apparently which calculate the quantity) and i added "input_to" to signify which modules take the variable as input. 