### PR TITLE
Switch CI to awvwgk/setup-fortran@main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,11 @@ jobs:
 
     steps:
 
-      # check out repo
       - name: Checkout repo
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -54,14 +53,13 @@ jobs:
     defaults:
       run:
         shell: bash
-
     steps:
-      # check out repo
+
       - name: Checkout repo
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -101,16 +99,12 @@ jobs:
         run: |
           pylint --jobs=2 --errors-only --exit-zero ./pynhm ./autotest
 
-
   test:
     name: ${{ matrix.os}} py${{ matrix.python-version }}
-
     runs-on: ${{ matrix.os }}
-
     defaults:
       run:
         shell: bash
-
     strategy:
       fail-fast: false
       matrix:
@@ -118,18 +112,22 @@ jobs:
         python-version: [ "3.8", "3.9" ]  #, "3.10"]
 
     steps:
+
       - name: Checkout repo
-        uses: actions/checkout@v2.4.0
-
-      - name: Install gfortran
-        uses: modflowpy/install-gfortran-action@v1
-
+        uses: actions/checkout@v3
+      
       - name: Set environment variables
         run: |
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
 
+      - name: Setup gfortran
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: gcc
+          version: 11
+
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/ci_examples.yaml
+++ b/.github/workflows/ci_examples.yaml
@@ -29,16 +29,19 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.4.0
 
+      - name: Install gfortran
+        uses: modflowpy/install-gfortran-action@v1
+
       - name: Download GIS files
         working-directory: examples
         run: |
           curl -LO https://github.com/EC-USGS/pynhm/releases/download/v2022.0.1/pynhm_gis.zip
           unzip pynhm_gis.zip
 
-
       - name: Set environment variables
         run: |
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
+          echo "SETUPTOOLS_ENABLE_FEATURES=legacy-editable" >> $GITHUB_ENV
 
       - name: Setup micromamba
         uses: mamba-org/provision-with-micromamba@main

--- a/autotest/test_cbh_to_netcdf.py
+++ b/autotest/test_cbh_to_netcdf.py
@@ -1,0 +1,106 @@
+import pathlib as pl
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from pynhm.utils import PrmsParameters
+from pynhm.utils.cbh_utils import cbh_files_to_df, cbh_files_to_netcdf
+from utils import assert_or_print
+
+var_cases = ["prcp", "rhavg", "tmax", "tmin"]
+
+
+@pytest.fixture
+def params(domain):
+    return PrmsParameters.load(domain["param_file"])
+
+
+@pytest.fixture(params=["no_params", "params"])
+def params_and_none(request, domain):
+    if request.param == "params":
+        return PrmsParameters.load(domain["param_file"])
+    else:
+        return None
+
+
+answer_key = {
+    "drb_2yr": {
+        "files_to_df": {
+            "prcp": 0.12495362248866715,
+        },
+        "df_concat": 40.7829059976932,
+        "np_dict": {
+            "prcp": 0.12495362248866718,
+            "rhavg": 62.738591579267386,
+            "tmax": 60.26121597238987,
+            "tmin": 40.00686281662687,
+            "time": 315532800.0,
+        },
+    },
+    "hru_1": {
+        "files_to_df": {
+            "prcp": 0.13502103505843072,
+        },
+        "df_concat": 34.968545798553144,
+        "np_dict": {
+            "prcp": 0.13502103505843072,
+            "tmax": 61.986048747913195,
+            "tmin": 42.78456761268781,
+            "time": 930873600.0,
+        },
+    },
+    "ucb_2yr": {
+        "files_to_df": {
+            "prcp": 0.046485653521159784,
+        },
+        "df_concat": 34.05471072235577,
+        "np_dict": {
+            "prcp": 0.046485653521159805,
+            "rhavg": 50.87569199962628,
+            "tmax": 56.74147989347377,
+            "tmin": 28.555185342801856,
+            "time": 315532800.0,
+        },
+    },
+}
+
+
+@pytest.mark.parametrize("var", [var_cases[0]])
+def test_cbh_files_to_df(domain, var, params):
+    the_file = domain["cbh_inputs"][var]
+    assert pl.Path(the_file).exists(), the_file
+    df = cbh_files_to_df(the_file, params)
+    results = {var: df.mean().mean()}
+    answers = answer_key[domain["domain_name"]]["files_to_df"]
+    assert_or_print(
+        results, answers, "files_to_df", print_ans=domain["print_ans"]
+    )
+    return
+
+
+def test_cbh_files_to_netcdf(domain, params, tmp_path):
+
+    nc_file = tmp_path / "cbh_files_to_netcdf.nc"
+    input_files_dict = domain["cbh_inputs"]
+    _ = cbh_files_to_netcdf(input_files_dict, params, nc_file)
+
+    answers = answer_key[domain["domain_name"]]["np_dict"]
+    results_ds = xr.open_dataset(nc_file)
+    results = {}
+    for var in answers.keys():
+        if var == "time":
+            results[var] = (
+                results_ds[var]
+                .values.astype("datetime64[s]")
+                .astype(np.int32)
+                .mean()
+            )
+        else:
+            results[var] = results_ds[var].mean().mean()
+
+    assert_or_print(
+        results, answers, "files_to_np_dict", print_ans=domain["print_ans"]
+    )
+
+    return

--- a/autotest/test_param_separate.py
+++ b/autotest/test_param_separate.py
@@ -10,7 +10,6 @@ from pynhm.base.timeseries import TimeseriesArray
 from pynhm.utils import separate_domain_params_to_ncdf
 from pynhm.utils.parameters import PrmsParameters
 
-
 n_time_steps = 10
 budget_type = None
 pynhm_processes = [

--- a/examples/01_automated_testing.ipynb
+++ b/examples/01_automated_testing.ipynb
@@ -1598,7 +1598,7 @@
     "pynhm_repo_root=$1\n",
     "\n",
     "cd ${pynhm_repo_root}/autotest\n",
-    "pytest --help | grep -A7 \"custom options\""
+    "pytest --help | grep -i -A7 \"custom options\""
    ]
   },
   {

--- a/pynhm/hydrology/PRMSSnow.py
+++ b/pynhm/hydrology/PRMSSnow.py
@@ -260,9 +260,16 @@ class PRMSSnow(StorageUnit):
         self.tmax_allsnow_c = (self.tmax_allsnow - 32.0) / 1.8
         del self.tmax_allsnow
 
-        # Deninv and denmaxinv not in variables nor in metadata but we can set them on self
-        # for convenience
-        self.deninv = one / self.den_init.copy()
+        # Deninv and denmaxinv not in variables nor in metadata but we can set
+        # them on self for convenience
+        if (self.den_init.shape == ()) or (
+            self.den_init.shape[0] != self.nhru
+        ):
+            den_init = np.ones(self.nhru, dtype=np.float64) * self.den_init
+        else:
+            den_init = self.den_init
+
+        self.deninv = one / den_init
         self.denmaxinv = one / self.den_max.copy()
 
         self.pkwater_equiv[:] = self.snowpack_init.copy()
@@ -1627,7 +1634,9 @@ class PRMSSnow(StorageUnit):
         # The snow depth depends on the previous snow pack water equivalent plus
         # the current net snow.
         self.pss[jj] = self.pss[jj] + self.net_snow[jj]  # [inches]
-        dpt_before_settle = self.pk_depth[jj] + self.net_snow[jj] * self.deninv
+        dpt_before_settle = (
+            self.pk_depth[jj] + self.net_snow[jj] * self.deninv[jj]
+        )
         dpt1 = dpt_before_settle + self.settle_const * (
             (self.pss[jj] * self.denmaxinv) - dpt_before_settle
         )

--- a/pynhm/static/metadata/variables.yaml
+++ b/pynhm/static/metadata/variables.yaml
@@ -2275,6 +2275,12 @@ rain_day:
     0: one
   type: int32
   units: none
+rhavg:
+  desc: Input/forcing daily mean relative humidity to each HRU
+  dimensions:
+    0: nhru
+  type: float64
+  units: percent
 recharge:
   desc: Recharge to the associated GWR as sum of soil_to_gw and ssr_to_gw for each
     HRU

--- a/pynhm/utils/cbh_utils.py
+++ b/pynhm/utils/cbh_utils.py
@@ -1,0 +1,273 @@
+import math
+import pathlib as pl
+from datetime import datetime
+from typing import Union
+
+import netCDF4 as nc4
+import numpy as np
+import pandas as pd
+
+from ..base import meta
+from ..utils.parameters import PrmsParameters
+
+zero = np.zeros((1))[0]
+one = np.ones((1))[0]
+
+# Compound types
+file_type = Union[str, pl.Path]
+fileish = Union[str, pl.Path, dict]
+
+nc4_to_np_types = {
+    "i4": "int32",
+    "i8": "int64",
+    "f4": "float32",
+    "f8": "float64",
+}
+np_to_nc4_types = {val: key for key, val in nc4_to_np_types.items()}
+
+created_line = "Created "
+written_line = "Written "
+hash_line = "##############"
+hash_line_official = "########################################"
+
+
+def _cbh_file_to_df(
+    the_file: file_type, params: PrmsParameters = None
+) -> pd.DataFrame:
+    # Only take cbh files that contain single variables
+    # JLM: this can be substantially simplified as
+    # we are only reading NHM CBH files now.
+    # Revisit with hru1.yaml
+
+    meta_lines = []
+    with open(the_file, "r") as file_open:
+        wh_hash_line = -1
+        the_line = ""
+        while hash_line not in the_line:
+            wh_hash_line += 1
+            the_line = file_open.readline()
+            if (
+                ("//" not in the_line)
+                and (created_line not in the_line)
+                and (written_line not in the_line)
+                and (hash_line not in the_line)
+            ):
+                meta_lines += [the_line.strip()]
+
+    col_names = []
+    var_count_dict = {}
+    line = meta_lines[-1]
+    line_split = line.split(" ")
+    key = line_split[0]
+    count = int(line_split[-1])
+    zs = math.ceil(math.log(count, 10))
+    if (params is None) or ("nhm_id" not in params.parameters):
+        col_names += [f"{key}{str(ii).zfill(zs)}" for ii in range(count)]
+    else:
+        col_names = np.char.add(
+            np.array([key]), params.parameters["nhm_id"].astype(str)
+        ).tolist()
+    var_count_dict[key] = count
+
+    if len(var_count_dict) > 1:
+        msg = f"cbh input files should contain only one variable each: {the_file}"
+        raise ValueError(msg)
+
+    dtypes = (["str"] * 6) + (["float64"] * len(col_names))
+    date_cols = ["Y", "m", "d", "H", "M", "S"]
+    col_names = date_cols + col_names
+    assert len(dtypes) == len(col_names)
+    dtype_dict = dict(zip(col_names, dtypes))
+    assert len(dtype_dict) == len(col_names)
+
+    # Some files erroneously specify the number of columns
+    # catch that here
+    data = pd.read_csv(
+        the_file,
+        nrows=1,
+        # names=col_names,  # dont specify names
+        header=None,  # dont use default header from first line
+        index_col=False,
+        skiprows=wh_hash_line + 1,
+        delim_whitespace=True,
+        dtype=dtype_dict,
+    )
+    msg = f"Number of actual data columns does not match metadata info: {meta_lines}"
+    assert len(data.columns) == len(col_names), msg
+    # JLM: is the above sufficient?
+
+    data = pd.read_csv(
+        the_file,
+        names=col_names,
+        index_col=False,
+        skiprows=wh_hash_line + 1,
+        delim_whitespace=True,
+        dtype=dtype_dict,
+    )
+
+    data["date"] = pd.to_datetime(
+        data.Y + "-" + data.m.str.zfill(2) + "-" + data.d.str.zfill(2)
+    )
+    # JLM TODO: Set datetime resolution to hours? or mins. Could do days but might look forward a bit.
+    data = data.drop(columns=set(date_cols))
+    data = data.set_index("date")
+
+    return data
+
+
+def _cbh_files_to_df(
+    file_dict: dict, params: PrmsParameters = None
+) -> pd.DataFrame:
+    dfs = [_cbh_file_to_df(val, params) for val in file_dict.values()]
+    return pd.concat(dfs, axis=1)
+
+
+def cbh_files_to_df(
+    files: fileish, params: PrmsParameters = None
+) -> pd.DataFrame:
+    if isinstance(files, (str, pl.Path)):
+        df = _cbh_file_to_df(files, params)
+    elif isinstance(files, (dict)):
+        df = _cbh_files_to_df(files, params)
+    else:
+        raise ValueError(
+            f'"files" argument of type {type(files)} not accepted.'
+        )
+    return df
+
+
+def _col_name_split(string: str) -> tuple:
+    char_list = list(string)
+    wh_digit = [ii for ii in range(len(char_list)) if char_list[ii].isdigit()]
+    return string[: wh_digit[0]], string[wh_digit[0] :]
+
+
+def cbh_df_to_np_dict(df: pd.DataFrame) -> dict:
+    # Convert to a multi-index? For getting to a dict of np arrays
+    # This might go elsewhere
+    col_name_tuples = [_col_name_split(kk) for kk, vv in df.iteritems()]
+    df.columns = pd.MultiIndex.from_tuples(col_name_tuples)
+    var_names = df.columns.unique(level=0)
+    np_dict = {}
+    np_dict["time"] = df.index.to_numpy(copy=True).astype("datetime64[s]")
+    spatial_ids = (
+        df.loc[:, var_names[0]].columns.values.astype(float).astype(int)
+    )
+    if spatial_ids[0] == "000":
+        np_dict["hru_ind"] = spatial_ids
+    else:
+        np_dict["nhm_id"] = spatial_ids
+    for vv in var_names:
+        np_dict[vv] = df[vv].to_numpy(copy=True)
+    return np_dict
+
+
+def cbh_n_hru(np_dict: dict) -> int:
+    odd_shapes = ["time", "hru_ind", "nhm_id"]
+    shapes = [
+        var.shape for key, var in np_dict.items() if key not in odd_shapes
+    ]
+    for ss in shapes:
+        assert shapes[0] == ss
+    return shapes[0][1]
+
+
+def cbh_n_time(np_dict: dict) -> int:
+    return np_dict["time"].shape[0]
+
+
+def cbh_files_to_np_dict(files: fileish, params: PrmsParameters) -> dict:
+    np_dict = cbh_df_to_np_dict(cbh_files_to_df(files, params))
+    return np_dict
+
+
+def _cbh_to_netcdf(
+    np_dict: dict,
+    filename: fileish,
+    clobber: bool = True,
+    output_vars: list = None,
+    zlib: bool = True,
+    complevel: int = 4,
+    global_atts: dict = {},
+    rename_vars={"precip": "prcp", "tminf": "tmin", "tmaxf": "tmax"},
+    chunk_sizes={"time": 30, "hru": 0},
+    time_units="days since 1979-01-01 00:00:00",
+    time_calendar="standard",
+) -> None:
+    # Default time chunk is for a read pattern of ~monthly at a time.
+
+    ds = nc4.Dataset(filename, "w", clobber=clobber)
+    ds.setncattr("Description", "Climate by HRU")
+    for key, val in global_atts.items():
+        ds.setncattr(key, val)
+
+    # Dimensions
+    # None for the len argument gives an unlimited dim
+    ds.createDimension("time", None)  # cbh_n_time(np_dict))
+    ds.createDimension("hru", cbh_n_hru(np_dict))
+
+    # Dim Variables
+    time = ds.createVariable("time", "f4", ("time",))
+
+    time[:] = nc4.date2num(np_dict["time"].astype(datetime), time_units)
+    time.units = time_units
+    # time.calendar = time_calendar
+
+    hru_name = "hru_ind" if "hru_ind" in np_dict.keys() else "nhm_id"
+    hruid = ds.createVariable(
+        hru_name, meta.get_types(hru_name)[hru_name], ("hru")
+    )
+    hru_meta_dict = {
+        "hru_ind": {
+            "type": "i4",
+            "desc": "Hydrologic Response Unit (HRU) index",
+            "cf_role": "timeseries_id",
+        },
+        "nhm_id": {
+            "type": "i4",
+            "desc": "NHM Hydrologic Response Unit (HRU) ID",
+            "cf_role": "timeseries_id",
+        },
+    }
+
+    for att, val in hru_meta_dict[hru_name].items():
+        hruid.setncattr(att, val)
+    hruid[:] = np_dict[hru_name]
+
+    # Variables
+    var_list = set(np_dict.keys()).difference({"time", "hru_ind", "nhm_id"})
+    if output_vars is not None:
+        var_list = [var for var in var_list if var in output_vars]
+
+    for vv in var_list:
+        vv_meta = meta.get_vars(vv)[vv]
+        vv_type = vv_meta["type"]
+        var_name_out = vv
+        if vv in rename_vars.keys():
+            var_name_out = rename_vars[vv]
+        var = ds.createVariable(
+            var_name_out,
+            vv_type,
+            ("time", "hru"),
+            fill_value=nc4.default_fillvals[np_to_nc4_types[vv_type]],
+            zlib=zlib,
+            complevel=complevel,
+            chunksizes=tuple(chunk_sizes.values()),
+        )
+        for att, val in vv_meta.items():
+            if att in ["_FillValue", "type", "dimensions"]:
+                continue
+            var.setncattr(att, val)
+        ds.variables[var_name_out][:, :] = np_dict[vv]
+
+    ds.close()
+    print(f"Wrote netcdf file: {filename}")
+    return
+
+
+def cbh_files_to_netcdf(
+    input_files_dict: dict, params: PrmsParameters, nc_file: fileish, **kwargs
+) -> None:
+    return _cbh_to_netcdf(
+        cbh_files_to_np_dict(input_files_dict, params), nc_file, **kwargs
+    )

--- a/pynhm/utils/netcdf_utils.py
+++ b/pynhm/utils/netcdf_utils.py
@@ -397,7 +397,7 @@ class NetCdfWrite(Accessor):
         for var_name, group_var_name in zip(variables, group_variables):
             variabletype = meta_netcdf_type(var_meta[var_name])
             if len(
-                set(["nhru", "ngw"]).intersection(
+                set(["nhru", "ngw", "nssr"]).intersection(
                     set(variable_dimensions[var_name])
                 )
             ):


### PR DESCRIPTION
[`awvgwk/setup-fortran@main`](https://github.com/awvwgk/setup-fortran) supports a selection of GCC versions on all platforms, with a (hopefully) more future-proof fix for Mac `.dylib` issues, and runner/version compatibility is tested daily, so we get a heads up if runners change underfoot &mdash; plus the maintainer is responsive to PRs. Overall probably better to rely on than `modflowpy/install-gfortran-action`

also bumped `actions/checkout` and `actions/setup-python` to latest major versions