### PR TITLE
Update notebook 01 for Windows operation

### DIFF
--- a/examples/01_automated_testing.ipynb
+++ b/examples/01_automated_testing.ipynb
@@ -103,12 +103,13 @@
     "import os\n",
     "import shutil\n",
     "import subprocess\n",
+    "import pathlib as pl\n",
     "\n",
     "# set up paths for notebook\n",
-    "pynhm_repo_root = str(pynhm.constants.__pynhm_root__.parent)     # this is as installed\n",
-    "pynhm_test_data_dir = os.path.join(pynhm_repo_root,'test_data')\n",
-    "pynhm_test_data_scripts_dir = os.path.join(pynhm_repo_root,'test_data','scripts')\n",
-    "pynhm_autotest_dir = os.path.join(pynhm_repo_root,'autotest')"
+    "pynhm_repo_root = pynhm.constants.__pynhm_root__.parent     # this is as installed; this is a pathlib path object\n",
+    "pynhm_test_data_dir = pynhm_repo_root / 'test_data'\n",
+    "pynhm_test_data_scripts_dir = pynhm_repo_root / 'test_data/scripts'\n",
+    "pynhm_autotest_dir = pynhm_repo_root / 'autotest'"
    ]
   },
   {
@@ -161,23 +162,22 @@
       "\n",
       "\n",
       "Directory: hru_1\n",
-      "cbh.nc control.test hru_1.yaml myparam.param prcp.cbh prcp.nc runtest.sh sf_data tmax.cbh tmax.nc tmin.cbh tmin.nc \n",
+      "cbh.nc  control.test  hru_1.yaml  myparam.param  prcp.cbh  prcp.nc  runtest.sh  sf_data  tmax.cbh  tmax.nc  tmin.cbh  tmin.nc  \n",
       "\n",
       "Directory: drb_2yr\n",
-      "cbh.nc control.test drb_2yr.yaml myparam.param prcp.cbh prcp.nc rhavg.cbh sf_data tmax.cbh tmax.nc tmin.cbh tmin.nc \n",
+      "cbh.nc  control.test  drb_2yr.yaml  myparam.param  prcp.cbh  prcp.nc  rhavg.cbh  sf_data  tmax.cbh  tmax.nc  tmin.cbh  tmin.nc  \n",
       "\n",
       "Directory: ucb_2yr\n",
-      "cbh.nc control.test myparam.param prcp.cbh prcp.nc rhavg.cbh runtest.sh sf_data tmax.cbh tmax.nc tmin.cbh tmin.nc ucb_2yr.yaml "
+      "cbh.nc  control.test  myparam.param  prcp.cbh  prcp.nc  rhavg.cbh  runtest.sh  sf_data  tmax.cbh  tmax.nc  tmin.cbh  tmin.nc  ucb_2yr.yaml  "
      ]
     }
    ],
    "source": [
     "for domain in ['hru_1', 'drb_2yr', 'ucb_2yr']:\n",
-    "    print('\\n\\nDirectory: ' + domain, end='\\n')\n",
-    "    dirname = os.path.join(pynhm_test_data_dir,domain)\n",
-    "    for entry in os.listdir(dirname):\n",
-    "        if os.path.isfile(os.path.join(dirname, entry)):\n",
-    "            print(entry, end=' ')"
+    "    print( f'\\n\\nDirectory: {domain}')\n",
+    "    dirname = pynhm_test_data_dir / domain\n",
+    "    for entry in dirname.iterdir():\n",
+    "        if entry.is_file(): print(entry.name, end='  ')"
    ]
   },
   {
@@ -199,8 +199,8 @@
    "source": [
     "# copy the master 'single_hru' control file to control.test\n",
     "for domain in ['hru_1']:\n",
-    "    src = os.path.join(pynhm_test_data_dir,'common','control.single_hru')\n",
-    "    dst = os.path.join(pynhm_test_data_dir,domain,'control.test')\n",
+    "    src = pynhm_test_data_dir / 'common/control.single_hru'\n",
+    "    dst = pynhm_test_data_dir / f'{domain}/control.test'\n",
     "    try:\n",
     "        shutil.copy(src, dst)\n",
     "    except shutil.SameFileError:\n",
@@ -208,8 +208,8 @@
     "    \n",
     "# copy the master 'multi_hru' control file to control.test    \n",
     "for domain in ['drb_2yr', 'ucb_2yr']:\n",
-    "    src = os.path.join(pynhm_test_data_dir,'common','control.multi_hru')\n",
-    "    dst = os.path.join(pynhm_test_data_dir,domain,'control.test')\n",
+    "    src = pynhm_test_data_dir / 'common/control.multi_hru'\n",
+    "    dst = pynhm_test_data_dir / f'{domain}/control.test'\n",
     "    try:\n",
     "        shutil.copy(src, dst)\n",
     "    except shutil.SameFileError:\n",
@@ -254,7 +254,7 @@
       "\n",
       "....                                                                     [100%]\n",
       "\n",
-      "============================= 4 passed in 48.83s ==============================\n",
+      "============================= 4 passed in 33.80s ==============================\n",
       "\n"
      ]
     }
@@ -314,15 +314,13 @@
    ],
    "source": [
     "from pprint import pprint as pp\n",
-    "dirname = os.path.join(pynhm_test_data_dir,'drb_2yr','output')\n",
+    "dirname = pynhm_test_data_dir / 'drb_2yr/output'\n",
     "filelist = []\n",
-    "for entry in os.listdir(dirname):\n",
-    "    if os.path.isfile(os.path.join(dirname, entry)):\n",
-    "        filelist.append(entry)\n",
-    "\n",
-    "#pp(list(filter(os.path.isfile, os.listdir(dirname))),compact=True)       \n",
+    "for entry in dirname.iterdir():\n",
+    "    if entry.is_file():\n",
+    "        filelist.append(entry.name)\n",
     "pp(filelist, compact=True)\n",
-    "print('\\n Number of files: ' + str(len(filelist)))"
+    "print(f'\\n Number of files: {len(filelist)}')"
    ]
   },
   {
@@ -367,7 +365,7 @@
       "\n",
       "...................                                                      [100%]\n",
       "\n",
-      "======================= 307 passed in 141.15s (0:02:21) =======================\n",
+      "======================= 307 passed in 99.69s (0:01:39) ========================\n",
       "\n"
      ]
     }
@@ -774,17 +772,17 @@
        "Data variables:\n",
        "    sroff    (time, nhm_id) float64 ...\n",
        "Attributes:\n",
-       "    Description:  PRMS output data</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-e9c87e3c-a564-4cfa-88c3-8d3f2b1eb7ff' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e9c87e3c-a564-4cfa-88c3-8d3f2b1eb7ff' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 14975</li><li><span class='xr-has-index'>nhm_id</span>: 1</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-614387e9-13ee-40b8-8855-3729dfbebf50' class='xr-section-summary-in' type='checkbox'  checked><label for='section-614387e9-13ee-40b8-8855-3729dfbebf50' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1979-01-01 ... 2019-12-31</div><input id='attrs-7cc12ddf-0392-4f89-989c-6a4f531c0128' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7cc12ddf-0392-4f89-989c-6a4f531c0128' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a283f179-c386-44c9-812d-cc8cc8485b9f' class='xr-var-data-in' type='checkbox'><label for='data-a283f179-c386-44c9-812d-cc8cc8485b9f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1979-01-01T00:00:00.000000000&#x27;, &#x27;1979-01-02T00:00:00.000000000&#x27;,\n",
+       "    Description:  PRMS output data</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c27b2024-478b-471e-89cd-58ead9b8c64b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c27b2024-478b-471e-89cd-58ead9b8c64b' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 14975</li><li><span class='xr-has-index'>nhm_id</span>: 1</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-53aee640-f807-465f-a445-11ee9929366f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-53aee640-f807-465f-a445-11ee9929366f' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1979-01-01 ... 2019-12-31</div><input id='attrs-294ad51f-58ab-41df-b6e6-fb5f6ec26017' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-294ad51f-58ab-41df-b6e6-fb5f6ec26017' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c37a23f0-88fd-4607-98ee-f960e75cd19c' class='xr-var-data-in' type='checkbox'><label for='data-c37a23f0-88fd-4607-98ee-f960e75cd19c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1979-01-01T00:00:00.000000000&#x27;, &#x27;1979-01-02T00:00:00.000000000&#x27;,\n",
        "       &#x27;1979-01-03T00:00:00.000000000&#x27;, ..., &#x27;2019-12-29T00:00:00.000000000&#x27;,\n",
        "       &#x27;2019-12-30T00:00:00.000000000&#x27;, &#x27;2019-12-31T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>nhm_id</span></div><div class='xr-var-dims'>(nhm_id)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>2</div><input id='attrs-150b1927-bc38-4e5f-b6b8-d6018a938c91' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-150b1927-bc38-4e5f-b6b8-d6018a938c91' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-46c477ac-3cb4-4ae3-901b-83bfa9287981' class='xr-var-data-in' type='checkbox'><label for='data-46c477ac-3cb4-4ae3-901b-83bfa9287981' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1b7a0296-de25-468b-ac59-d0d22f858b4e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1b7a0296-de25-468b-ac59-d0d22f858b4e' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>sroff</span></div><div class='xr-var-dims'>(time, nhm_id)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-64a12926-878d-40fc-b8d1-dd2b5d08f977' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-64a12926-878d-40fc-b8d1-dd2b5d08f977' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bc156cb7-1323-4e62-95b5-1c3757bf3dc8' class='xr-var-data-in' type='checkbox'><label for='data-bc156cb7-1323-4e62-95b5-1c3757bf3dc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>desc :</span></dt><dd>Surface runoff to the stream network for each HRU</dd><dt><span>type :</span></dt><dd>float64</dd><dt><span>units :</span></dt><dd>inches</dd><dt><span>var_category :</span></dt><dd>mass flux</dd></dl></div><div class='xr-var-data'><pre>[14975 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5dc37a23-3c6d-4e21-876c-2905920bc0b8' class='xr-section-summary-in' type='checkbox'  ><label for='section-5dc37a23-3c6d-4e21-876c-2905920bc0b8' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ac0109f9-bd7f-4c01-a354-e2013f8af49a' class='xr-index-data-in' type='checkbox'/><label for='index-ac0109f9-bd7f-4c01-a354-e2013f8af49a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1979-01-01&#x27;, &#x27;1979-01-02&#x27;, &#x27;1979-01-03&#x27;, &#x27;1979-01-04&#x27;,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>nhm_id</span></div><div class='xr-var-dims'>(nhm_id)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>2</div><input id='attrs-424c71df-5370-46a8-8778-dd943bb7a0dc' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-424c71df-5370-46a8-8778-dd943bb7a0dc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-04107aab-b033-4234-bc4d-9e5efbf1fd8c' class='xr-var-data-in' type='checkbox'><label for='data-04107aab-b033-4234-bc4d-9e5efbf1fd8c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-45349fa7-57df-4703-a6e7-d3c3cfc0a1e9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-45349fa7-57df-4703-a6e7-d3c3cfc0a1e9' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>sroff</span></div><div class='xr-var-dims'>(time, nhm_id)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-29dd9f0c-dcb6-4e54-bab6-3e610afe0fb9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-29dd9f0c-dcb6-4e54-bab6-3e610afe0fb9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6642be18-4166-4cae-bec7-8bc6478bb2ec' class='xr-var-data-in' type='checkbox'><label for='data-6642be18-4166-4cae-bec7-8bc6478bb2ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>desc :</span></dt><dd>Surface runoff to the stream network for each HRU</dd><dt><span>type :</span></dt><dd>float64</dd><dt><span>units :</span></dt><dd>inches</dd><dt><span>var_category :</span></dt><dd>mass flux</dd></dl></div><div class='xr-var-data'><pre>[14975 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bbf45995-a310-4c63-bf75-088d2eea135e' class='xr-section-summary-in' type='checkbox'  ><label for='section-bbf45995-a310-4c63-bf75-088d2eea135e' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-3f4e1c19-833d-4e8f-b4ba-0a52ced2b8d7' class='xr-index-data-in' type='checkbox'/><label for='index-3f4e1c19-833d-4e8f-b4ba-0a52ced2b8d7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1979-01-01&#x27;, &#x27;1979-01-02&#x27;, &#x27;1979-01-03&#x27;, &#x27;1979-01-04&#x27;,\n",
        "               &#x27;1979-01-05&#x27;, &#x27;1979-01-06&#x27;, &#x27;1979-01-07&#x27;, &#x27;1979-01-08&#x27;,\n",
        "               &#x27;1979-01-09&#x27;, &#x27;1979-01-10&#x27;,\n",
        "               ...\n",
        "               &#x27;2019-12-22&#x27;, &#x27;2019-12-23&#x27;, &#x27;2019-12-24&#x27;, &#x27;2019-12-25&#x27;,\n",
        "               &#x27;2019-12-26&#x27;, &#x27;2019-12-27&#x27;, &#x27;2019-12-28&#x27;, &#x27;2019-12-29&#x27;,\n",
        "               &#x27;2019-12-30&#x27;, &#x27;2019-12-31&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=14975, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>nhm_id</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-15ac47f0-ff1f-4bd3-b1a3-55f5dbf323ce' class='xr-index-data-in' type='checkbox'/><label for='index-15ac47f0-ff1f-4bd3-b1a3-55f5dbf323ce' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Int64Index([2], dtype=&#x27;int64&#x27;, name=&#x27;nhm_id&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b8b6f749-e12f-49cb-b976-682bc2e60d48' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b8b6f749-e12f-49cb-b976-682bc2e60d48' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Description :</span></dt><dd>PRMS output data</dd></dl></div></li></ul></div></div>"
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=14975, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>nhm_id</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-90f3d3be-78ab-442c-951b-d71115157243' class='xr-index-data-in' type='checkbox'/><label for='index-90f3d3be-78ab-442c-951b-d71115157243' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Int64Index([2], dtype=&#x27;int64&#x27;, name=&#x27;nhm_id&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-af828031-215e-4163-af45-bc62f9d13903' class='xr-section-summary-in' type='checkbox'  checked><label for='section-af828031-215e-4163-af45-bc62f9d13903' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Description :</span></dt><dd>PRMS output data</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1183,20 +1181,20 @@
        "Data variables:\n",
        "    sroff    (time, nhm_id) float64 ...\n",
        "Attributes:\n",
-       "    Description:  PRMS output data</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d319aa0d-78b2-4531-89a3-5696a6ffd33b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d319aa0d-78b2-4531-89a3-5696a6ffd33b' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 731</li><li><span class='xr-has-index'>nhm_id</span>: 765</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-75fee735-bdad-4866-9158-12ff9c2969d4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-75fee735-bdad-4866-9158-12ff9c2969d4' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1979-01-01 ... 1980-12-31</div><input id='attrs-9499c17d-434c-4c47-8e60-f5f3bcae2ff9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9499c17d-434c-4c47-8e60-f5f3bcae2ff9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-db5169c3-7781-4b1e-b1fc-0f5da5b126d7' class='xr-var-data-in' type='checkbox'><label for='data-db5169c3-7781-4b1e-b1fc-0f5da5b126d7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1979-01-01T00:00:00.000000000&#x27;, &#x27;1979-01-02T00:00:00.000000000&#x27;,\n",
+       "    Description:  PRMS output data</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-dfad3886-08ab-4d8d-87ac-af918e31824d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-dfad3886-08ab-4d8d-87ac-af918e31824d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 731</li><li><span class='xr-has-index'>nhm_id</span>: 765</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-206173cd-1eeb-4231-bf3a-bd8bd0f418d8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-206173cd-1eeb-4231-bf3a-bd8bd0f418d8' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1979-01-01 ... 1980-12-31</div><input id='attrs-291d6824-ab23-480b-bfe9-4fbd57400839' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-291d6824-ab23-480b-bfe9-4fbd57400839' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-70a55580-583d-4c71-8a20-27785d5dafd0' class='xr-var-data-in' type='checkbox'><label for='data-70a55580-583d-4c71-8a20-27785d5dafd0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1979-01-01T00:00:00.000000000&#x27;, &#x27;1979-01-02T00:00:00.000000000&#x27;,\n",
        "       &#x27;1979-01-03T00:00:00.000000000&#x27;, ..., &#x27;1980-12-29T00:00:00.000000000&#x27;,\n",
        "       &#x27;1980-12-30T00:00:00.000000000&#x27;, &#x27;1980-12-31T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>nhm_id</span></div><div class='xr-var-dims'>(nhm_id)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>5307 5308 5309 ... 7249 7250 7251</div><input id='attrs-3a2cb196-0990-4381-b286-7fa03a77bad2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3a2cb196-0990-4381-b286-7fa03a77bad2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c8326523-e4db-46b4-aa7a-2e76259f5180' class='xr-var-data-in' type='checkbox'><label for='data-c8326523-e4db-46b4-aa7a-2e76259f5180' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5307, 5308, 5309, ..., 7249, 7250, 7251])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d3089919-0c51-4d3f-a380-3b7dd80d7e8c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d3089919-0c51-4d3f-a380-3b7dd80d7e8c' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>sroff</span></div><div class='xr-var-dims'>(time, nhm_id)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-756a8990-b83e-48f7-966b-c1a899e3f943' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-756a8990-b83e-48f7-966b-c1a899e3f943' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a25e7e4e-d7ca-4e72-9a30-716fb7ec3266' class='xr-var-data-in' type='checkbox'><label for='data-a25e7e4e-d7ca-4e72-9a30-716fb7ec3266' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>desc :</span></dt><dd>Surface runoff to the stream network for each HRU</dd><dt><span>type :</span></dt><dd>float64</dd><dt><span>units :</span></dt><dd>inches</dd><dt><span>var_category :</span></dt><dd>mass flux</dd></dl></div><div class='xr-var-data'><pre>[559215 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9a67b2bc-e950-4613-8bf4-79d562e42afa' class='xr-section-summary-in' type='checkbox'  ><label for='section-9a67b2bc-e950-4613-8bf4-79d562e42afa' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-e5e2e093-5181-44df-81a4-d87c68c34021' class='xr-index-data-in' type='checkbox'/><label for='index-e5e2e093-5181-44df-81a4-d87c68c34021' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1979-01-01&#x27;, &#x27;1979-01-02&#x27;, &#x27;1979-01-03&#x27;, &#x27;1979-01-04&#x27;,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>nhm_id</span></div><div class='xr-var-dims'>(nhm_id)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>5307 5308 5309 ... 7249 7250 7251</div><input id='attrs-fce9f44b-f369-458a-8a27-107e3b27fc27' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fce9f44b-f369-458a-8a27-107e3b27fc27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5bbb3c4a-831d-4d76-8531-dfc53f51238f' class='xr-var-data-in' type='checkbox'><label for='data-5bbb3c4a-831d-4d76-8531-dfc53f51238f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5307, 5308, 5309, ..., 7249, 7250, 7251])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-07633507-71fd-45cf-97c2-b18c519693f2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-07633507-71fd-45cf-97c2-b18c519693f2' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>sroff</span></div><div class='xr-var-dims'>(time, nhm_id)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-91384340-6b54-4ce7-a2bc-98aca0dfac40' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-91384340-6b54-4ce7-a2bc-98aca0dfac40' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ddb575d0-4389-4b39-a914-d6162887f6e7' class='xr-var-data-in' type='checkbox'><label for='data-ddb575d0-4389-4b39-a914-d6162887f6e7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>desc :</span></dt><dd>Surface runoff to the stream network for each HRU</dd><dt><span>type :</span></dt><dd>float64</dd><dt><span>units :</span></dt><dd>inches</dd><dt><span>var_category :</span></dt><dd>mass flux</dd></dl></div><div class='xr-var-data'><pre>[559215 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b2d49a00-b028-4470-ae60-545d872dd259' class='xr-section-summary-in' type='checkbox'  ><label for='section-b2d49a00-b028-4470-ae60-545d872dd259' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-e35f1a87-50b0-4992-891c-37ef7f9623b5' class='xr-index-data-in' type='checkbox'/><label for='index-e35f1a87-50b0-4992-891c-37ef7f9623b5' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1979-01-01&#x27;, &#x27;1979-01-02&#x27;, &#x27;1979-01-03&#x27;, &#x27;1979-01-04&#x27;,\n",
        "               &#x27;1979-01-05&#x27;, &#x27;1979-01-06&#x27;, &#x27;1979-01-07&#x27;, &#x27;1979-01-08&#x27;,\n",
        "               &#x27;1979-01-09&#x27;, &#x27;1979-01-10&#x27;,\n",
        "               ...\n",
        "               &#x27;1980-12-22&#x27;, &#x27;1980-12-23&#x27;, &#x27;1980-12-24&#x27;, &#x27;1980-12-25&#x27;,\n",
        "               &#x27;1980-12-26&#x27;, &#x27;1980-12-27&#x27;, &#x27;1980-12-28&#x27;, &#x27;1980-12-29&#x27;,\n",
        "               &#x27;1980-12-30&#x27;, &#x27;1980-12-31&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=731, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>nhm_id</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ee0b761e-f12f-46b8-ab74-e13e7a26475d' class='xr-index-data-in' type='checkbox'/><label for='index-ee0b761e-f12f-46b8-ab74-e13e7a26475d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Int64Index([5307, 5308, 5309, 5310, 5311, 5312, 5313, 5314, 5315, 5316,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=731, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>nhm_id</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-63c9051f-95f8-4470-94e4-5aff4baffbc4' class='xr-index-data-in' type='checkbox'/><label for='index-63c9051f-95f8-4470-94e4-5aff4baffbc4' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Int64Index([5307, 5308, 5309, 5310, 5311, 5312, 5313, 5314, 5315, 5316,\n",
        "            ...\n",
        "            7242, 7243, 7244, 7245, 7246, 7247, 7248, 7249, 7250, 7251],\n",
-       "           dtype=&#x27;int64&#x27;, name=&#x27;nhm_id&#x27;, length=765))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cb56a925-b392-4e02-b53f-8d8eee5ef9dc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cb56a925-b392-4e02-b53f-8d8eee5ef9dc' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Description :</span></dt><dd>PRMS output data</dd></dl></div></li></ul></div></div>"
+       "           dtype=&#x27;int64&#x27;, name=&#x27;nhm_id&#x27;, length=765))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-64c7dbdc-81ab-41f5-8f3d-056e0de471c5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-64c7dbdc-81ab-41f5-8f3d-056e0de471c5' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Description :</span></dt><dd>PRMS output data</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1595,22 +1593,22 @@
        "Data variables:\n",
        "    sroff    (time, nhm_id) float64 ...\n",
        "Attributes:\n",
-       "    Description:  PRMS output data</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f0ae3c8d-b8a9-41e7-aa84-86fa86e1c1da' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f0ae3c8d-b8a9-41e7-aa84-86fa86e1c1da' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 731</li><li><span class='xr-has-index'>nhm_id</span>: 3851</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-07bb06c3-56ec-4828-b447-67882471a2c2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-07bb06c3-56ec-4828-b447-67882471a2c2' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1979-01-01 ... 1980-12-31</div><input id='attrs-4ecb221b-d296-4546-8cf8-80d5cb9a268e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4ecb221b-d296-4546-8cf8-80d5cb9a268e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-48d4671d-d23e-47d8-af51-699d80886397' class='xr-var-data-in' type='checkbox'><label for='data-48d4671d-d23e-47d8-af51-699d80886397' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1979-01-01T00:00:00.000000000&#x27;, &#x27;1979-01-02T00:00:00.000000000&#x27;,\n",
+       "    Description:  PRMS output data</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-dd09ffaf-9aa2-4ec9-8166-af6bec82c3de' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-dd09ffaf-9aa2-4ec9-8166-af6bec82c3de' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 731</li><li><span class='xr-has-index'>nhm_id</span>: 3851</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4f165ef7-f3a0-4301-bb80-2dd57d276c1a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4f165ef7-f3a0-4301-bb80-2dd57d276c1a' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1979-01-01 ... 1980-12-31</div><input id='attrs-d1f1a422-0b78-4d9c-a7c3-8e2eb7ed4367' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d1f1a422-0b78-4d9c-a7c3-8e2eb7ed4367' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0ebbf4f8-c696-4fa7-a368-4e1a81ad29ee' class='xr-var-data-in' type='checkbox'><label for='data-0ebbf4f8-c696-4fa7-a368-4e1a81ad29ee' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;1979-01-01T00:00:00.000000000&#x27;, &#x27;1979-01-02T00:00:00.000000000&#x27;,\n",
        "       &#x27;1979-01-03T00:00:00.000000000&#x27;, ..., &#x27;1980-12-29T00:00:00.000000000&#x27;,\n",
        "       &#x27;1980-12-30T00:00:00.000000000&#x27;, &#x27;1980-12-31T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>nhm_id</span></div><div class='xr-var-dims'>(nhm_id)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>84763 84853 84760 ... 85637 85654</div><input id='attrs-95ebd59d-8718-4026-9133-4b56020bd154' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-95ebd59d-8718-4026-9133-4b56020bd154' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ddcfa47c-46ff-4119-b021-295c2d874103' class='xr-var-data-in' type='checkbox'><label for='data-ddcfa47c-46ff-4119-b021-295c2d874103' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([84763, 84853, 84760, ..., 83094, 85637, 85654])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a68bddef-6391-4c59-a3ca-2861b013cff5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a68bddef-6391-4c59-a3ca-2861b013cff5' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>sroff</span></div><div class='xr-var-dims'>(time, nhm_id)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-1c9ced40-3476-49ec-821c-0b35f76e5c2e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1c9ced40-3476-49ec-821c-0b35f76e5c2e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-31699e25-bfb3-4a3a-ab1d-4fa459f74b6c' class='xr-var-data-in' type='checkbox'><label for='data-31699e25-bfb3-4a3a-ab1d-4fa459f74b6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>desc :</span></dt><dd>Surface runoff to the stream network for each HRU</dd><dt><span>type :</span></dt><dd>float64</dd><dt><span>units :</span></dt><dd>inches</dd><dt><span>var_category :</span></dt><dd>mass flux</dd></dl></div><div class='xr-var-data'><pre>[2815081 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6985ab67-869c-4983-9a88-1774dbd76aaf' class='xr-section-summary-in' type='checkbox'  ><label for='section-6985ab67-869c-4983-9a88-1774dbd76aaf' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-9000cdcf-f2aa-448e-b3a4-f9422751b8ac' class='xr-index-data-in' type='checkbox'/><label for='index-9000cdcf-f2aa-448e-b3a4-f9422751b8ac' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1979-01-01&#x27;, &#x27;1979-01-02&#x27;, &#x27;1979-01-03&#x27;, &#x27;1979-01-04&#x27;,\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>nhm_id</span></div><div class='xr-var-dims'>(nhm_id)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>84763 84853 84760 ... 85637 85654</div><input id='attrs-7e78e4fa-b00c-4361-b884-6f411631be65' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7e78e4fa-b00c-4361-b884-6f411631be65' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-998c924e-74cd-4d44-b4b2-efdbfa8f8351' class='xr-var-data-in' type='checkbox'><label for='data-998c924e-74cd-4d44-b4b2-efdbfa8f8351' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([84763, 84853, 84760, ..., 83094, 85637, 85654])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-852fb31b-8fdc-4ba6-be38-3f1eb5f76a7f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-852fb31b-8fdc-4ba6-be38-3f1eb5f76a7f' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>sroff</span></div><div class='xr-var-dims'>(time, nhm_id)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-897056f3-6ec8-4949-935f-0669dcf40df2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-897056f3-6ec8-4949-935f-0669dcf40df2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-94e242f1-e491-46b2-a199-7497602cc375' class='xr-var-data-in' type='checkbox'><label for='data-94e242f1-e491-46b2-a199-7497602cc375' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>desc :</span></dt><dd>Surface runoff to the stream network for each HRU</dd><dt><span>type :</span></dt><dd>float64</dd><dt><span>units :</span></dt><dd>inches</dd><dt><span>var_category :</span></dt><dd>mass flux</dd></dl></div><div class='xr-var-data'><pre>[2815081 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4edfb329-c661-41ed-9ea9-2e4385427487' class='xr-section-summary-in' type='checkbox'  ><label for='section-4edfb329-c661-41ed-9ea9-2e4385427487' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-1e642d46-0863-482f-9ef8-9eb6e42b1157' class='xr-index-data-in' type='checkbox'/><label for='index-1e642d46-0863-482f-9ef8-9eb6e42b1157' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1979-01-01&#x27;, &#x27;1979-01-02&#x27;, &#x27;1979-01-03&#x27;, &#x27;1979-01-04&#x27;,\n",
        "               &#x27;1979-01-05&#x27;, &#x27;1979-01-06&#x27;, &#x27;1979-01-07&#x27;, &#x27;1979-01-08&#x27;,\n",
        "               &#x27;1979-01-09&#x27;, &#x27;1979-01-10&#x27;,\n",
        "               ...\n",
        "               &#x27;1980-12-22&#x27;, &#x27;1980-12-23&#x27;, &#x27;1980-12-24&#x27;, &#x27;1980-12-25&#x27;,\n",
        "               &#x27;1980-12-26&#x27;, &#x27;1980-12-27&#x27;, &#x27;1980-12-28&#x27;, &#x27;1980-12-29&#x27;,\n",
        "               &#x27;1980-12-30&#x27;, &#x27;1980-12-31&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=731, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>nhm_id</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-456f9b38-4915-4a17-be66-cff7fae937ae' class='xr-index-data-in' type='checkbox'/><label for='index-456f9b38-4915-4a17-be66-cff7fae937ae' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Int64Index([84763, 84853, 84760, 84847, 84762, 84849, 85188, 84761, 84848,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=731, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>nhm_id</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-38336ac0-b878-461f-be33-19d0cbf2f4b8' class='xr-index-data-in' type='checkbox'/><label for='index-38336ac0-b878-461f-be33-19d0cbf2f4b8' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Int64Index([84763, 84853, 84760, 84847, 84762, 84849, 85188, 84761, 84848,\n",
        "            84748,\n",
        "            ...\n",
        "            83128, 83129, 83126, 83127, 83093, 83096, 83092, 83094, 85637,\n",
        "            85654],\n",
-       "           dtype=&#x27;int64&#x27;, name=&#x27;nhm_id&#x27;, length=3851))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6eae2f10-f21a-4c19-9480-6f5ee7152a26' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6eae2f10-f21a-4c19-9480-6f5ee7152a26' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Description :</span></dt><dd>PRMS output data</dd></dl></div></li></ul></div></div>"
+       "           dtype=&#x27;int64&#x27;, name=&#x27;nhm_id&#x27;, length=3851))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-31634d83-23d9-4d65-b250-6278f9ea2c97' class='xr-section-summary-in' type='checkbox'  checked><label for='section-31634d83-23d9-4d65-b250-6278f9ea2c97' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Description :</span></dt><dd>PRMS output data</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1636,7 +1634,6 @@
     }
    ],
    "source": [
-    "import pathlib as pl\n",
     "import xarray as xr\n",
     "\n",
     "for domain in [\"hru_1\", \"drb_2yr\", \"ucb_2yr\"]:\n",
@@ -1734,7 +1731,7 @@
       "\n",
       "........................................................................ [ 59%]\n",
       "\n",
-      "...........................X.Xx.X..Xx..XXX.X.xx...                       [100%]\n",
+      "..........................X...XxXx.X...X.XX.x.X..x                       [100%]\n",
       "\n",
       "============================== warnings summary ===============================\n",
       "\n",
@@ -1776,9 +1773,9 @@
       "\n",
       "autotest/test_model.py::test_model[ucb_2yr-nhm]\n",
       "\n",
-      "autotest/test_solar_geom.py::test_solar_geom[ucb_2yr-from_prms_file]\n",
-      "\n",
       "autotest/test_solar_geom.py::test_solar_geom[ucb_2yr-compute]\n",
+      "\n",
+      "autotest/test_solar_geom.py::test_solar_geom[ucb_2yr-from_prms_file]\n",
       "\n",
       "  E:\\projects\\enterprise_capacity\\git\\pynhm\\pynhm\\atmosphere\\PRMSSolarGeometry.py:328: UserWarning: 275/1409466 locations-times with negative potential solar radiation.\n",
       "\n",
@@ -1786,13 +1783,13 @@
       "\n",
       "\n",
       "\n",
-      "autotest/test_runoff.py::TestPRMSRunoffDomain::test_init[drb_2yr-numpy]\n",
-      "\n",
       "autotest/test_runoff.py::TestPRMSRunoffDomain::test_init[drb_2yr-numba]\n",
       "\n",
-      "autotest/test_runoff.py::TestPRMSRunoffDomain::test_init[ucb_2yr-numba]\n",
+      "autotest/test_runoff.py::TestPRMSRunoffDomain::test_init[drb_2yr-numpy]\n",
       "\n",
       "autotest/test_runoff.py::TestPRMSRunoffDomain::test_init[ucb_2yr-numpy]\n",
+      "\n",
+      "autotest/test_runoff.py::TestPRMSRunoffDomain::test_init[ucb_2yr-numba]\n",
       "\n",
       "  E:\\projects\\enterprise_capacity\\git\\pynhm\\pynhm\\base\\budget.py:317: UserWarning: The flux unit balance not equal to the change in unit storage: PRMSRunoff\n",
       "\n",
@@ -1808,9 +1805,9 @@
       "\n",
       "autotest/test_snow.py::TestPRMSSnow::test_init[hru_1-numba]\n",
       "\n",
-      "autotest/test_snow.py::TestPRMSSnow::test_init[drb_2yr-numba]\n",
-      "\n",
       "autotest/test_snow.py::TestPRMSSnow::test_init[ucb_2yr-numpy]\n",
+      "\n",
+      "autotest/test_snow.py::TestPRMSSnow::test_init[drb_2yr-numba]\n",
       "\n",
       "  E:\\projects\\enterprise_capacity\\git\\pynhm\\pynhm\\base\\budget.py:317: UserWarning: The flux unit balance not equal to the change in unit storage: PRMSSnow\n",
       "\n",
@@ -1820,7 +1817,7 @@
       "\n",
       "-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n",
       "\n",
-      "===== 110 passed, 4 xfailed, 8 xpassed, 22 warnings in 267.13s (0:04:27) ======\n",
+      "===== 110 passed, 4 xfailed, 8 xpassed, 22 warnings in 221.63s (0:03:41) ======\n",
       "\n"
      ]
     }
@@ -1841,9 +1838,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pynhm_nb] *",
+   "display_name": "Python 3.10.8 ('pynhm_nb')",
    "language": "python",
-   "name": "conda-env-pynhm_nb-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1856,6 +1853,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bbe09fef76cf7230519a15f5b5db67b9bc006ff3be45d40b7521af6d93d5409f"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/examples_env.yml
+++ b/examples/examples_env.yml
@@ -31,6 +31,7 @@ dependencies:
   - jupyter_contrib_nbextensions
   - nb_conda_kernels
   - pydot
+  - shapely<2.0.0
   - pip:
       - click != 8.1.0
       - black


### PR DESCRIPTION
Third time: replaced bash calls with Python equivalents. Attempted to dump calls to Python's 'os.path' module in favor of pathlib. Removed string concatenation ('+') in favor of use of fstrings.